### PR TITLE
error fix for couchdb cluster deployment enable cluster action

### DIFF
--- a/roles/couchdb2/defaults/main.yaml
+++ b/roles/couchdb2/defaults/main.yaml
@@ -2,3 +2,4 @@
 magic_cookie: "I like chocolate cookies."
 configure_cluster: false
 release_candidate: RC4
+COUNT_NODES: 3

--- a/roles/couchdb2/tasks/configure-cluster.yaml
+++ b/roles/couchdb2/tasks/configure-cluster.yaml
@@ -1,7 +1,7 @@
 ---
 
 - name: enable the cluster
-  uri: status_code=201 HEADER_Content-Type="application/json" user=admin password=password method=POST url=http://127.0.0.1:5984/_cluster_setup body='{"action":"enable_cluster","bind_address":"0.0.0.0","username":"admin","password":"password"}'
+  uri: status_code=201 HEADER_Content-Type="application/json" user=admin password=password method=POST body_format=json url=http://127.0.0.1:5984/_cluster_setup body='{"action":"enable_cluster","bind_address":"0.0.0.0","username":"admin","password":"password","node_count":"{{COUNT_NODES}}"}'
 # when: inventory_hostname == "{{ groups.couches[0] }}" 
 
 - name: add nodes to the cluster


### PR DESCRIPTION
- body_format flag missing from enable_cluster action ansible parses json bosy as raw without flag
- enable_cluster action requires cluster nodes count as mandatory parameter
@kafecho @hinesmr 